### PR TITLE
Allows for table.placement to be an empty string with no options loaded

### DIFF
--- a/R/stargazer-internal.R
+++ b/R/stargazer-internal.R
@@ -6285,7 +6285,7 @@ function(libname, pkgname) {
       tp.error <- FALSE
       for (i in 1:nchar(table.placement)) {
         ch <- substring(table.placement,i,i)
-        if (!(ch %in% c("h","t","b","p","!","H"))) (tp.error <- TRUE)
+        if (!(ch %in% c("h","t","b","p","!","H", ""))) (tp.error <- TRUE)
       }
       if (tp.error) { error.present <- c(error.present, "% Error: Argument 'table.placement' can only consist of \"h\",\"t\",\"b\",\"p\",\"!\",\"H\".\n") }
     }


### PR DESCRIPTION
In current version of stargazer you cannot create a table without options, e.g 
`\begin{table}[]
...
\end{table}`

is not allowed. But there's no reason this shouldn't be allowed.
