### PR TITLE
updated handling of plm()

### DIFF
--- a/R/stargazer-internal.R
+++ b/R/stargazer-internal.R
@@ -2594,7 +2594,7 @@ function(libname, pkgname) {
   	else if (object.name$call[1]=="hurdle()") {
   	  return("hurdle")
   	}  	
-  	else if (object.name$call[1]=="plm()") {
+  	else if (object.name$call[1] %in% c("plm::plm()", "plm()")) {
   	  return("plm")
   	}
     else if (object.name$call[1]=="pgmm()") {


### PR DESCRIPTION
I know that this repository is a read-only mirror and not maintained. Just staging this change here to reference in an email conversation with `stargazer`'s author, since [the project's source code isn't hosted in any source code management tool, as far as I can tell](https://cran.r-project.org/web/packages/stargazer/index.html).

This code shows the issue that @brianmassaro and I have observed. The strategy that `stargazer` uses to determine model types is really fragile because it's based on string matching. This means that it matters whether your code creates a `plm` model (in our example) with `plm()` or `plm::plm()`.

I think it would be better to replace the internals of `.model.identify()` with code that uses `is()` and / or `class()`, but that would be a fairly major change. For now, @brianmassaro and I would like to just propose the change in this PR's diff.

```r
library(plm)
data("Grunfeld", package = "plm")

# models with and without '::'
mod <- plm(
    inv ~ value + capital
    , data = Grunfeld
    , model = "pooling"
)
mod_w_colons <- plm::plm(
    inv ~ value + capital
    , data = Grunfeld
    , model = "pooling"
)

f <- function(object.name){
    print(object.name$call[1])
}
f(mod)
f(mod_w_colons)

# this works
stargazer::stargazer(mod)

# this fails with:
#     * % Error: Unrecognized object type.
stargazer::stargazer(mod_w_colons)
```