### PR TITLE
fix omit fixed effects label bug

### DIFF
--- a/R/stargazer-internal.R
+++ b/R/stargazer-internal.R
@@ -79,6 +79,10 @@ function(libname, pkgname) {
 
   	  # add RHS variables and coefficients
   	  coef.var <- .coefficient.variables(object.name)
+	  # cbind will drop vector rows, if vector is longer than matrix. Pad matrix if this is the case.
+	  if (length(coef.var) > nrow(.global.coef.vars.by.model)) {
+            .global.coef.vars.by.model <<- rbind(.global.coef.vars.by.model, .global.coef.vars.by.model[length(coef.var)-nrow(.global.coef.vars.by.model),])
+          }
   	  .global.coef.vars.by.model <<-  cbind(.global.coef.vars.by.model, coef.var)
 
   	  temp.gcv <- rep(NA,each=1,times=max.length)


### PR DESCRIPTION
The following code produces a bug with the omit labels:

```y <- rbinom(100, 1, 0.5)
x <- rnorm(100)
z <- rnorm(100)
a <- rnorm(100)

fit1.lm <- lm(y~a+x)
fit2.lm <- lm(y~a+x+z)
# doesnt work, z should be 'yes' column 2
stargazer(fit1.lm, fit2.lm,
              omit=c("x", "z"), 
              omit.labels=c("x", "z")) 
```

This bug is due to a 'cbind' command dropping items if you try to cbind(matrix,vector) when length(vector) is larger than nrow(matrix).

I am not 100% sure, but I think that this 'dropping' issue is not by design in the code and will fix this bug without causing other issues.